### PR TITLE
API Gateway

### DIFF
--- a/lambdas/hello.ts
+++ b/lambdas/hello.ts
@@ -1,10 +1,10 @@
-import { APIGatewayEvent, Handler } from "aws-lambda";
+import { APIGatewayProxyEventV2, Handler } from "aws-lambda";
 
-export const handler: Handler = async function (event: APIGatewayEvent) {
+export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   console.log("request:", JSON.stringify(event, undefined, 2));
   return {
     statusCode: 200,
     headers: { "Content-Type": "text/plain" },
-    body: `Hello, CDK! You've hit ${event.path}\n`,
+    body: `Hello ${event.rawPath}`,
   };
 };

--- a/lambdas/hello.ts
+++ b/lambdas/hello.ts
@@ -1,6 +1,6 @@
-import { Handler } from "aws-lambda";
+import { APIGatewayEvent, Handler } from "aws-lambda";
 
-export const handler: Handler = async function (event) {
+export const handler: Handler = async function (event: APIGatewayEvent) {
   console.log("request:", JSON.stringify(event, undefined, 2));
   return {
     statusCode: 200,

--- a/lib/resports-aws-cdk-stack.ts
+++ b/lib/resports-aws-cdk-stack.ts
@@ -1,6 +1,7 @@
 import * as cdk from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import * as apigw from "aws-cdk-lib/aws-apigateway";
+import { HttpApi } from "@aws-cdk/aws-apigatewayv2-alpha";
+
 import {
   NodejsFunction,
   NodejsFunctionProps,
@@ -22,9 +23,7 @@ export class ResportsAwsCdkStack extends cdk.Stack {
       ...nodeJsFunctionProps,
     });
 
-    // defines an API Gateway REST API resource backed by our "hello" function
-    new apigw.LambdaRestApi(this, "Endpoint", {
-      handler: hello,
-    });
+    // defines an API Gateway HTTP API resource
+    const httpApi = new HttpApi(this, "HttpApi");
   }
 }

--- a/lib/resports-aws-cdk-stack.ts
+++ b/lib/resports-aws-cdk-stack.ts
@@ -32,10 +32,15 @@ export class ResportsAwsCdkStack extends cdk.Stack {
     // defines an API Gateway HTTP API resource
     const httpApi = new HttpApi(this, "HttpApi");
 
+    // Attaches our integrated function to the "/hello" path
     httpApi.addRoutes({
       path: "/hello",
       methods: [HttpMethod.GET],
       integration: helloIntegration,
+    });
+
+    new cdk.CfnOutput(this, "apiUrl", {
+      value: httpApi.url ? httpApi.url : "No URL found",
     });
   }
 }

--- a/lib/resports-aws-cdk-stack.ts
+++ b/lib/resports-aws-cdk-stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as apigw from "aws-cdk-lib/aws-apigateway";
 import {
   NodejsFunction,
   NodejsFunctionProps,
@@ -19,6 +20,11 @@ export class ResportsAwsCdkStack extends cdk.Stack {
     const hello = new NodejsFunction(this, "HelloHandler", {
       entry: join(__dirname, "/../lambdas", "hello.ts"),
       ...nodeJsFunctionProps,
+    });
+
+    // defines an API Gateway REST API resource backed by our "hello" function
+    new apigw.LambdaRestApi(this, "Endpoint", {
+      handler: hello,
     });
   }
 }

--- a/lib/resports-aws-cdk-stack.ts
+++ b/lib/resports-aws-cdk-stack.ts
@@ -1,6 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
-import { HttpApi } from "@aws-cdk/aws-apigatewayv2-alpha";
+import { HttpApi, HttpMethod } from "@aws-cdk/aws-apigatewayv2-alpha";
 import {
   NodejsFunction,
   NodejsFunctionProps,
@@ -31,5 +31,11 @@ export class ResportsAwsCdkStack extends cdk.Stack {
 
     // defines an API Gateway HTTP API resource
     const httpApi = new HttpApi(this, "HttpApi");
+
+    httpApi.addRoutes({
+      path: "/hello",
+      methods: [HttpMethod.GET],
+      integration: helloIntegration,
+    });
   }
 }

--- a/lib/resports-aws-cdk-stack.ts
+++ b/lib/resports-aws-cdk-stack.ts
@@ -1,13 +1,13 @@
 import * as cdk from "aws-cdk-lib";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import { HttpApi } from "@aws-cdk/aws-apigatewayv2-alpha";
-
 import {
   NodejsFunction,
   NodejsFunctionProps,
 } from "aws-cdk-lib/aws-lambda-nodejs";
 import { Construct } from "constructs";
 import { join } from "path";
+import { HttpLambdaIntegration } from "@aws-cdk/aws-apigatewayv2-integrations-alpha";
 
 export class ResportsAwsCdkStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
@@ -22,6 +22,12 @@ export class ResportsAwsCdkStack extends cdk.Stack {
       entry: join(__dirname, "/../lambdas", "hello.ts"),
       ...nodeJsFunctionProps,
     });
+
+    // Integrate our hello function with the HTTP API. This connects the API route to the lambda service
+    const helloIntegration = new HttpLambdaIntegration(
+      "HelloIntegration",
+      hello
+    );
 
     // defines an API Gateway HTTP API resource
     const httpApi = new HttpApi(this, "HttpApi");

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-cdk/aws-apigatewayv2-alpha": "^2.64.0-alpha.0",
+        "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.64.0-alpha.0",
         "aws-cdk-lib": "2.64.0",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21"
@@ -64,6 +65,19 @@
         "node": ">= 14.15.0"
       },
       "peerDependencies": {
+        "aws-cdk-lib": "^2.64.0",
+        "constructs": "^10.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/aws-apigatewayv2-integrations-alpha": {
+      "version": "2.64.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-integrations-alpha/-/aws-apigatewayv2-integrations-alpha-2.64.0-alpha.0.tgz",
+      "integrity": "sha512-WACfXYe7xVBzvRC3agMCVP8Bm+MZSHTsJLoye2DXwGPHzed54AzlUJ+1d7TJkeWyujL2R4L9YLUCiwnRe+LBtQ==",
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/aws-apigatewayv2-alpha": "2.64.0-alpha.0",
         "aws-cdk-lib": "^2.64.0",
         "constructs": "^10.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "resports-aws-cdk",
       "version": "0.1.0",
       "dependencies": {
+        "@aws-cdk/aws-apigatewayv2-alpha": "^2.64.0-alpha.0",
         "aws-cdk-lib": "2.64.0",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21"
@@ -54,6 +55,18 @@
       "version": "2.0.53",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.53.tgz",
       "integrity": "sha512-gDNdL+Lf2oBhYOr61ovO/QV+Hw2WzSGuKoz+O7Dc56DAF9OiTTc5DZA4la6FUcLPIamlVwxVdASqWXJZfRf64A=="
+    },
+    "node_modules/@aws-cdk/aws-apigatewayv2-alpha": {
+      "version": "2.64.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/aws-apigatewayv2-alpha/-/aws-apigatewayv2-alpha-2.64.0-alpha.0.tgz",
+      "integrity": "sha512-/pRlT5Z7i2uIXJ9ZNOHWnNNSwpnsiXOtL++8/mb2gyxih6VjwBBmKk2b+MX0uE0X55OhViOc0Uh7GyPWwkHvjw==",
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.64.0",
+        "constructs": "^10.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@aws-cdk/aws-apigatewayv2-alpha": "^2.64.0-alpha.0",
+    "@aws-cdk/aws-apigatewayv2-integrations-alpha": "^2.64.0-alpha.0",
     "aws-cdk-lib": "2.64.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "typescript": "~4.9.5"
   },
   "dependencies": {
+    "@aws-cdk/aws-apigatewayv2-alpha": "^2.64.0-alpha.0",
     "aws-cdk-lib": "2.64.0",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"


### PR DESCRIPTION
This PR introduces the basic code for a HTTP API using `aws-cdk`. The libraries required are still in alpha after several years now, but versioning is working correctly and this PR includes a working path on "/hello" with working lambda integration and types. 