### PR TITLE
Cognito user pool

### DIFF
--- a/constructs/cognito-user-pool.ts
+++ b/constructs/cognito-user-pool.ts
@@ -53,6 +53,8 @@ export class CognitoUserPool extends Construct {
         tempPasswordValidity: Duration.days(7),
       },
 
+      deletionProtection: true,
+
       // TODO: post-confirmation lambda triggers
 
       // Adjust default account recovery to use email only, not SMS

--- a/constructs/cognito-user-pool.ts
+++ b/constructs/cognito-user-pool.ts
@@ -1,0 +1,7 @@
+import { Construct } from "constructs";
+
+export class CognitoUserPool extends Construct {
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+  }
+}

--- a/constructs/cognito-user-pool.ts
+++ b/constructs/cognito-user-pool.ts
@@ -60,6 +60,15 @@ export class CognitoUserPool extends Construct {
     });
 
     // Configure the App Client
-    userPool.addClient("DemoAppClient", {});
+    const appClient = userPool.addClient("DemoAppClient", {
+      userPoolClientName: "test-app-client",
+    });
+
+    // Configure the Cognito hosted domain where the auth sign-up/log-in pages will be hosted.
+    const domain = userPool.addDomain("DemoUserPoolDomain", {
+      cognitoDomain: {
+        domainPrefix: "resports-demo-app",
+      },
+    });
   }
 }

--- a/constructs/cognito-user-pool.ts
+++ b/constructs/cognito-user-pool.ts
@@ -1,7 +1,13 @@
 import { Construct } from "constructs";
+import * as cognito from "aws-cdk-lib/aws-cognito";
 
 export class CognitoUserPool extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);
+
+    const userPool = new cognito.UserPool(this, "TestUserPool", {
+      userPoolName: "test-user-pool",
+      signInCaseSensitive: false, // case insensitive is preferred in most situations
+    });
   }
 }

--- a/constructs/cognito-user-pool.ts
+++ b/constructs/cognito-user-pool.ts
@@ -8,6 +8,30 @@ export class CognitoUserPool extends Construct {
     const userPool = new cognito.UserPool(this, "TestUserPool", {
       userPoolName: "test-user-pool",
       signInCaseSensitive: false, // case insensitive is preferred in most situations
+
+      // Allow self sign up, else users could only be signed up by an administrator
+      selfSignUpEnabled: true,
+
+      // Allow users to sign in with either username or email
+      signInAliases: {
+        username: true,
+        email: true,
+      },
+
+      // Users must provide full name on sign-up, but cannot change it thereafter
+      standardAttributes: {
+        fullname: {
+          required: true,
+          mutable: false,
+        },
+      },
+
+      // Users can opt-in to MFA, but only TOTP apps are avaiable as an authentication method
+      mfa: cognito.Mfa.OPTIONAL,
+      mfaSecondFactor: {
+        sms: false,
+        otp: true,
+      },
     });
   }
 }

--- a/constructs/cognito-user-pool.ts
+++ b/constructs/cognito-user-pool.ts
@@ -1,5 +1,6 @@
 import { Construct } from "constructs";
 import * as cognito from "aws-cdk-lib/aws-cognito";
+import { Duration } from "aws-cdk-lib";
 
 export class CognitoUserPool extends Construct {
   constructor(scope: Construct, id: string) {
@@ -18,11 +19,20 @@ export class CognitoUserPool extends Construct {
         email: true,
       },
 
+      // Configure the attributes that you want to keep active when an update to their value is pending. Your users can receive messages and sign in with the original attribute value until they verify the new value.
+      keepOriginal: {
+        email: true,
+      },
+
       // Users must provide full name on sign-up, but cannot change it thereafter
       standardAttributes: {
         fullname: {
           required: true,
           mutable: false,
+        },
+        email: {
+          required: true,
+          mutable: true,
         },
       },
 
@@ -32,6 +42,24 @@ export class CognitoUserPool extends Construct {
         sms: false,
         otp: true,
       },
+
+      // TODO: customise password policy
+      passwordPolicy: {
+        minLength: 8,
+        requireLowercase: true,
+        requireUppercase: true,
+        requireDigits: true,
+        requireSymbols: true,
+        tempPasswordValidity: Duration.days(7),
+      },
+
+      // TODO: post-confirmation lambda triggers
+
+      // Adjust default account recovery to use email only, not SMS
+      accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
     });
+
+    // Configure the App Client
+    userPool.addClient("DemoAppClient", {});
   }
 }

--- a/lib/resports-aws-cdk-stack.ts
+++ b/lib/resports-aws-cdk-stack.ts
@@ -8,10 +8,14 @@ import {
 import { Construct } from "constructs";
 import { join } from "path";
 import { HttpLambdaIntegration } from "@aws-cdk/aws-apigatewayv2-integrations-alpha";
+import { CognitoUserPool } from "../constructs/cognito-user-pool";
 
 export class ResportsAwsCdkStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
+
+    // Instantiate the separately defined cognito construct
+    new CognitoUserPool(this, "CognitoUserPool");
 
     const nodeJsFunctionProps: NodejsFunctionProps = {
       runtime: lambda.Runtime.NODEJS_16_X, // execution environment


### PR DESCRIPTION
This PR adds a Cognito user pool with the correct configuration for sign-in, App Client, domains, and other settings. This user pool does not support federated identities at this stage, and instead only supports standard password/email login. 