### PR TITLE
Client reuse error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@typescript-eslint/eslint-plugin": "^5.53.0",
         "@typescript-eslint/parser": "^5.53.0",
         "aws-cdk": "2.64.0",
+        "esbuild": "^0.17.11",
         "eslint": "^8.34.0",
         "husky": "^8.0.3",
         "jest": "^29.4.1",
@@ -876,6 +877,358 @@
       },
       "bin": {
         "which": "bin/which"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.11.tgz",
+      "integrity": "sha512-CdyX6sRVh1NzFCsf5vw3kULwlAhfy9wVt8SZlrhQ7eL2qBjGbFhRBWkkAzuZm9IIEOCKJw4DXA6R85g+qc8RDw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.11.tgz",
+      "integrity": "sha512-QnK4d/zhVTuV4/pRM4HUjcsbl43POALU2zvBynmrrqZt9LPcLA3x1fTZPBg2RRguBQnJcnU059yKr+bydkntjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.11.tgz",
+      "integrity": "sha512-3PL3HKtsDIXGQcSCKtWD/dy+mgc4p2Tvo2qKgKHj9Yf+eniwFnuoQ0OUhlSfAEpKAFzF9N21Nwgnap6zy3L3MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.11.tgz",
+      "integrity": "sha512-pJ950bNKgzhkGNO3Z9TeHzIFtEyC2GDQL3wxkMApDEghYx5Qers84UTNc1bAxWbRkuJOgmOha5V0WUeh8G+YGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.11.tgz",
+      "integrity": "sha512-iB0dQkIHXyczK3BZtzw1tqegf0F0Ab5texX2TvMQjiJIWXAfM4FQl7D909YfXWnB92OQz4ivBYQ2RlxBJrMJOw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.11.tgz",
+      "integrity": "sha512-7EFzUADmI1jCHeDRGKgbnF5sDIceZsQGapoO6dmw7r/ZBEKX7CCDnIz8m9yEclzr7mFsd+DyasHzpjfJnmBB1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.11.tgz",
+      "integrity": "sha512-iPgenptC8i8pdvkHQvXJFzc1eVMR7W2lBPrTE6GbhR54sLcF42mk3zBOjKPOodezzuAz/KSu8CPyFSjcBMkE9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.11.tgz",
+      "integrity": "sha512-M9iK/d4lgZH0U5M1R2p2gqhPV/7JPJcRz+8O8GBKVgqndTzydQ7B2XGDbxtbvFkvIs53uXTobOhv+RyaqhUiMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.11.tgz",
+      "integrity": "sha512-Qxth3gsWWGKz2/qG2d5DsW/57SeA2AmpSMhdg9TSB5Svn2KDob3qxfQSkdnWjSd42kqoxIPy3EJFs+6w1+6Qjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.11.tgz",
+      "integrity": "sha512-dB1nGaVWtUlb/rRDHmuDQhfqazWE0LMro/AIbT2lWM3CDMHJNpLckH+gCddQyhhcLac2OYw69ikUMO34JLt3wA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.11.tgz",
+      "integrity": "sha512-aCWlq70Q7Nc9WDnormntGS1ar6ZFvUpqr8gXtO+HRejRYPweAFQN615PcgaSJkZjhHp61+MNLhzyVALSF2/Q0g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.11.tgz",
+      "integrity": "sha512-cGeGNdQxqY8qJwlYH1BP6rjIIiEcrM05H7k3tR7WxOLmD1ZxRMd6/QIOWMb8mD2s2YJFNRuNQ+wjMhgEL2oCEw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.11.tgz",
+      "integrity": "sha512-BdlziJQPW/bNe0E8eYsHB40mYOluS+jULPCjlWiHzDgr+ZBRXPtgMV1nkLEGdpjrwgmtkZHEGEPaKdS/8faLDA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.11.tgz",
+      "integrity": "sha512-MDLwQbtF+83oJCI1Cixn68Et/ME6gelmhssPebC40RdJaect+IM+l7o/CuG0ZlDs6tZTEIoxUe53H3GmMn8oMA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.11.tgz",
+      "integrity": "sha512-4N5EMESvws0Ozr2J94VoUD8HIRi7X0uvUv4c0wpTHZyZY9qpaaN7THjosdiW56irQ4qnJ6Lsc+i+5zGWnyqWqQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.11.tgz",
+      "integrity": "sha512-rM/v8UlluxpytFSmVdbCe1yyKQd/e+FmIJE2oPJvbBo+D0XVWi1y/NQ4iTNx+436WmDHQBjVLrbnAQLQ6U7wlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.11.tgz",
+      "integrity": "sha512-4WaAhuz5f91h3/g43VBGdto1Q+X7VEZfpcWGtOFXnggEuLvjV+cP6DyLRU15IjiU9fKLLk41OoJfBFN5DhPvag==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.11.tgz",
+      "integrity": "sha512-UBj135Nx4FpnvtE+C8TWGp98oUgBcmNmdYgl5ToKc0mBHxVVqVE7FUS5/ELMImOp205qDAittL6Ezhasc2Ev/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.11.tgz",
+      "integrity": "sha512-1/gxTifDC9aXbV2xOfCbOceh5AlIidUrPsMpivgzo8P8zUtczlq1ncFpeN1ZyQJ9lVs2hILy1PG5KPp+w8QPPg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.11.tgz",
+      "integrity": "sha512-vtSfyx5yRdpiOW9yp6Ax0zyNOv9HjOAw8WaZg3dF5djEHKKm3UnoohftVvIJtRh0Ec7Hso0RIdTqZvPXJ7FdvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.11.tgz",
+      "integrity": "sha512-GFPSLEGQr4wHFTiIUJQrnJKZhZjjq4Sphf+mM76nQR6WkQn73vm7IsacmBRPkALfpOCHsopSvLgqdd4iUW2mYw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.11.tgz",
+      "integrity": "sha512-N9vXqLP3eRL8BqSy8yn4Y98cZI2pZ8fyuHx6lKjiG2WABpT2l01TXdzq5Ma2ZUBzfB7tx5dXVhge8X9u0S70ZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -2943,6 +3296,43 @@
       "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.17.11",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.11.tgz",
+      "integrity": "sha512-pAMImyokbWDtnA/ufPxjQg0fYo2DDuzAlqwnDvbXqHLphe+m80eF++perYKVm8LeTuj2zUuFXC+xgSVxyoHUdg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.17.11",
+        "@esbuild/android-arm64": "0.17.11",
+        "@esbuild/android-x64": "0.17.11",
+        "@esbuild/darwin-arm64": "0.17.11",
+        "@esbuild/darwin-x64": "0.17.11",
+        "@esbuild/freebsd-arm64": "0.17.11",
+        "@esbuild/freebsd-x64": "0.17.11",
+        "@esbuild/linux-arm": "0.17.11",
+        "@esbuild/linux-arm64": "0.17.11",
+        "@esbuild/linux-ia32": "0.17.11",
+        "@esbuild/linux-loong64": "0.17.11",
+        "@esbuild/linux-mips64el": "0.17.11",
+        "@esbuild/linux-ppc64": "0.17.11",
+        "@esbuild/linux-riscv64": "0.17.11",
+        "@esbuild/linux-s390x": "0.17.11",
+        "@esbuild/linux-x64": "0.17.11",
+        "@esbuild/netbsd-x64": "0.17.11",
+        "@esbuild/openbsd-x64": "0.17.11",
+        "@esbuild/sunos-x64": "0.17.11",
+        "@esbuild/win32-arm64": "0.17.11",
+        "@esbuild/win32-ia32": "0.17.11",
+        "@esbuild/win32-x64": "0.17.11"
       }
     },
     "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@typescript-eslint/eslint-plugin": "^5.53.0",
     "@typescript-eslint/parser": "^5.53.0",
     "aws-cdk": "2.64.0",
+    "esbuild": "^0.17.11",
     "eslint": "^8.34.0",
     "husky": "^8.0.3",
     "jest": "^29.4.1",

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -16,10 +16,10 @@ export const databaseConfig = {
   DATABASE_HOST: env.DATABASE_HOST,
 };
 
-export const database = new Client({
+export const databaseClientConfig = {
   user: databaseConfig.DATABASE_USER,
   host: databaseConfig.DATABASE_HOST,
   database: databaseConfig.DATABASE_NAME,
   password: databaseConfig.DATABASE_PASSWORD,
   port: 5432,
-});
+};

--- a/src/lambdas/addChannel.ts
+++ b/src/lambdas/addChannel.ts
@@ -2,7 +2,8 @@ import { APIGatewayProxyEventV2, Handler } from "aws-lambda";
 import { is } from "superstruct";
 import { ChannelStruct } from "@/types";
 import { insertChannel } from "@/helpers";
-import { database } from "@/config";
+import { databaseClientConfig } from "@/config";
+import { Client } from "pg";
 
 export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   if (!event.body) {
@@ -27,6 +28,7 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
     });
   }
 
+  const database = new Client({ ...databaseClientConfig });
   await database.connect();
 
   await insertChannel(database, channelInformation);

--- a/src/lambdas/addSavedChannel.ts
+++ b/src/lambdas/addSavedChannel.ts
@@ -2,7 +2,8 @@ import { APIGatewayProxyEventV2, Handler } from "aws-lambda";
 import { is } from "superstruct";
 import { SavedChannelStruct } from "@/types";
 import { insertSavedChannel } from "@/helpers";
-import { database } from "@/config";
+import { databaseClientConfig } from "@/config";
+import { Client } from "pg";
 
 export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   if (!event.body) {
@@ -27,6 +28,7 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
     });
   }
 
+  const database = new Client({ ...databaseClientConfig });
   await database.connect();
 
   await insertSavedChannel(

--- a/src/lambdas/addUser.ts
+++ b/src/lambdas/addUser.ts
@@ -1,8 +1,9 @@
 import { Handler, APIGatewayProxyEventV2 } from "aws-lambda";
 import { is } from "superstruct";
-import { database } from "@/config";
 import { upsertUser } from "@/helpers";
 import { UserStruct } from "@/types";
+import { Client } from "pg";
+import { databaseClientConfig } from "@/config";
 
 export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   if (!event.body) {
@@ -27,6 +28,7 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
     });
   }
 
+  const database = new Client({ ...databaseClientConfig });
   await database.connect();
 
   await upsertUser(database, userInformation);

--- a/src/lambdas/databaseOverview.ts
+++ b/src/lambdas/databaseOverview.ts
@@ -1,8 +1,10 @@
 import { Handler } from "aws-lambda";
-import { database } from "@/config";
+import { databaseClientConfig } from "@/config";
 import { selectAllFromTable } from "@/helpers";
+import { Client } from "pg";
 
 export const handler: Handler = async function () {
+  const database = new Client({ ...databaseClientConfig });
   await database.connect();
 
   const users = await selectAllFromTable(database, "users");

--- a/src/lambdas/deleteChannel.ts
+++ b/src/lambdas/deleteChannel.ts
@@ -1,7 +1,8 @@
 import { APIGatewayProxyEventV2, Handler } from "aws-lambda";
 import { is, object, string } from "superstruct";
 import { deleteChannel } from "@/helpers";
-import { database } from "@/config";
+import { databaseClientConfig } from "@/config";
+import { Client } from "pg";
 
 const ChannelIdStruct = object({
   channel_id: string(),
@@ -30,6 +31,7 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
     });
   }
 
+  const database = new Client({ ...databaseClientConfig });
   await database.connect();
 
   const result = await deleteChannel(database, channelInformation.channel_id);

--- a/src/lambdas/deleteSavedChannel.ts
+++ b/src/lambdas/deleteSavedChannel.ts
@@ -2,7 +2,8 @@ import { APIGatewayProxyEventV2, Handler } from "aws-lambda";
 import { is } from "superstruct";
 import { SavedChannelStruct } from "@/types";
 import { safelyRemoveSavedChannel } from "@/helpers";
-import { database } from "@/config";
+import { databaseClientConfig } from "@/config";
+import { Client } from "pg";
 
 export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   const savedChannelInformation = event.queryStringParameters;
@@ -27,6 +28,7 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
     });
   }
 
+  const database = new Client({ ...databaseClientConfig });
   await database.connect();
 
   const result = await safelyRemoveSavedChannel(

--- a/src/lambdas/deleteUser.ts
+++ b/src/lambdas/deleteUser.ts
@@ -1,7 +1,8 @@
 import { APIGatewayProxyEventV2, Handler } from "aws-lambda";
 import { is, object, string } from "superstruct";
-import { database } from "@/config";
+import { databaseClientConfig } from "@/config";
 import { removeAllUserSavedChannels, deleteUser } from "@/helpers";
+import { Client } from "pg";
 
 const UserIdStruct = object({
   user_id: string(),
@@ -30,6 +31,7 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
     });
   }
 
+  const database = new Client({ ...databaseClientConfig });
   await database.connect();
 
   await removeAllUserSavedChannels(database, userInformation.user_id);

--- a/src/lambdas/getSavedChannel.ts
+++ b/src/lambdas/getSavedChannel.ts
@@ -2,7 +2,8 @@ import { APIGatewayProxyEventV2, Handler } from "aws-lambda";
 import { is } from "superstruct";
 import { SavedChannelStruct } from "../types";
 import { selectSavedChannelByUserAndChannel } from "@/helpers";
-import { database } from "@/config";
+import { databaseClientConfig } from "@/config";
+import { Client } from "pg";
 
 export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   const savedChannelInformation = event.queryStringParameters;
@@ -27,6 +28,7 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
     });
   }
 
+  const database = new Client({ ...databaseClientConfig });
   await database.connect();
 
   const result = await selectSavedChannelByUserAndChannel(

--- a/src/lambdas/getUserSavedChannels.ts
+++ b/src/lambdas/getUserSavedChannels.ts
@@ -1,7 +1,8 @@
 import { APIGatewayProxyEventV2, Handler } from "aws-lambda";
 import { is, object, string } from "superstruct";
 import { selectSavedChannelsByUserId } from "@/helpers";
-import { database } from "@/config";
+import { databaseClientConfig } from "@/config";
+import { Client } from "pg";
 
 const UserIdStruct = object({
   user_id: string(),
@@ -30,6 +31,7 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
     });
   }
 
+  const database = new Client({ ...databaseClientConfig });
   await database.connect();
 
   const result = await selectSavedChannelsByUserId(

--- a/src/lambdas/initialiseDatabase.ts
+++ b/src/lambdas/initialiseDatabase.ts
@@ -1,8 +1,10 @@
 import { Handler } from "aws-lambda";
-import { database } from "@/config";
+import { databaseClientConfig } from "@/config";
 import { createNewTables, dropExistingTables } from "@/helpers";
+import { Client } from "pg";
 
 export const handler: Handler = async function () {
+  const database = new Client({ ...databaseClientConfig });
   await database.connect();
 
   await dropExistingTables(database);


### PR DESCRIPTION
This PR fixes a critical error where postgres clients could not be reused by lambdas. This appeared to be due to defining clients in a single file then exporting the same client to several handlers. The solution is to define a new, separate client within each handler. 

This PR also includes a small fix whereby `esbuild` was removed from peer dependencies, breaking the build process.