### PR TITLE
Consolidate "fail" and "error" responses

### DIFF
--- a/src/helpers/apiResonseGenerator.ts
+++ b/src/helpers/apiResonseGenerator.ts
@@ -1,4 +1,8 @@
-// Inspired by JSend https://github.com/omniti-labs/jsend
+/**
+ * Inspired by JSend https://github.com/omniti-labs/jsend with simplifications.
+ * "Fail" and "Error" are ultimately treated the same way on the frontend, so they've
+ * been combined into a simple "fail with message" type response
+ */
 
 export const createSuccessResponse = (
   statusCode: number,
@@ -14,29 +18,13 @@ export const createSuccessResponse = (
   });
 };
 
-export const createFailResponse = (statusCode: number, data: object) => {
+export const createFailResponse = (statusCode: number, message: string) => {
   return JSON.stringify({
     statusCode: statusCode,
     headers: { "Content-Type": "application/json" },
     body: {
       status: "fail",
-      data: data,
-    },
-  });
-};
-
-export const createErrorResponse = (
-  statusCode: number,
-  message: string,
-  data: object | null = null
-) => {
-  return JSON.stringify({
-    statusCode: statusCode,
-    headers: { "Content-Type": "application/json" },
-    body: {
-      status: "error",
       message: message,
-      data,
     },
   });
 };

--- a/src/helpers/handleConnectDb.ts
+++ b/src/helpers/handleConnectDb.ts
@@ -1,5 +1,5 @@
 import { connectDb } from "@/config";
-import { createErrorResponse } from "./apiResonseGenerator";
+import { createFailResponse } from "./apiResonseGenerator";
 /**
  * Abstracts the common DB connection operation in lambda handlers.
  *
@@ -15,15 +15,9 @@ export const handleDbConnection = async () => {
     await connectDb();
     return null; // returns null when the connection is successful
   } catch (error) {
-    if (error instanceof Error) {
-      return createErrorResponse(
-        500,
-        "An error occurred while attempting to connect to the database."
-      );
-    } else {
-      return createErrorResponse(500, "An unknown error occurred", {
-        error: JSON.stringify(error),
-      });
-    }
+    return createFailResponse(
+      500,
+      "An error occurred while attempting to connect to the database."
+    );
   }
 };

--- a/src/lambdas/addChannel.ts
+++ b/src/lambdas/addChannel.ts
@@ -10,17 +10,13 @@ import {
 
 export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   if (!event.body) {
-    return createFailResponse(400, {
-      channel: "Channel data is required",
-    });
+    return createFailResponse(400, "Channel data is required");
   }
 
   const channelInformation = JSON.parse(event.body);
 
   if (!is(channelInformation, ChannelStruct)) {
-    return createFailResponse(400, {
-      channel: "Incorrect channel data format",
-    });
+    return createFailResponse(400, "Incorrect channel data format");
   }
 
   const errorResponse = await handleDbConnection();
@@ -33,8 +29,6 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
       channel: insertedChannel,
     });
   } else {
-    return createFailResponse(500, {
-      channel: "Failed to add channel",
-    });
+    return createFailResponse(500, "Failed to add channel");
   }
 };

--- a/src/lambdas/addSavedChannel.ts
+++ b/src/lambdas/addSavedChannel.ts
@@ -14,17 +14,13 @@ const SavedChannelRequestStruct = object({
 
 export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   if (!event.body) {
-    return createFailResponse(400, {
-      savedChannel: "User and/or channel data is missing.",
-    });
+    return createFailResponse(400, "User and/or channel data is missing.");
   }
 
   const requestBody = JSON.parse(event.body);
 
   if (!is(requestBody, SavedChannelRequestStruct)) {
-    return createFailResponse(400, {
-      savedChannel: "Incorrect user and/or channel data.",
-    });
+    return createFailResponse(400, "Incorrect user and/or channel data.");
   }
 
   const errorResponse = await handleDbConnection();
@@ -40,8 +36,6 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
       user: updatedUser,
     });
   } else {
-    return createFailResponse(500, {
-      user: "Failed to save channel",
-    });
+    return createFailResponse(500, "Failed to save channel");
   }
 };

--- a/src/lambdas/addUser.ts
+++ b/src/lambdas/addUser.ts
@@ -10,17 +10,13 @@ import {
 
 export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   if (!event.body) {
-    return createFailResponse(400, {
-      user: "User data is required.",
-    });
+    return createFailResponse(400, "User data is required.");
   }
 
   const userInformation = JSON.parse(event.body);
 
   if (!is(userInformation, UserStruct)) {
-    return createFailResponse(400, {
-      user: "User data is invalid.",
-    });
+    return createFailResponse(400, "User data is invalid.");
   }
 
   const errorResponse = await handleDbConnection();
@@ -33,8 +29,6 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
       user: upsertedUser,
     });
   } else {
-    return createFailResponse(500, {
-      user: "Failed to add user",
-    });
+    return createFailResponse(500, "Failed to add user");
   }
 };

--- a/src/lambdas/deleteChannel.ts
+++ b/src/lambdas/deleteChannel.ts
@@ -15,15 +15,11 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   const channelInformation = event.pathParameters;
 
   if (!channelInformation) {
-    return createFailResponse(400, {
-      channel: "Channel ID is required",
-    });
+    return createFailResponse(400, "Channel ID is required");
   }
 
   if (!is(channelInformation, ChannelIdStruct)) {
-    return createFailResponse(400, {
-      channel: "Channel ID is incorrectly formatted",
-    });
+    return createFailResponse(400, "Channel ID is incorrectly formatted");
   }
 
   const errorResponse = await handleDbConnection();
@@ -34,8 +30,6 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   if (deletedChannel) {
     return createSuccessResponse(204, null);
   } else {
-    return createFailResponse(500, {
-      channel: "Failed to delete channel",
-    });
+    return createFailResponse(500, "Failed to delete channel");
   }
 };

--- a/src/lambdas/deleteSavedChannel.ts
+++ b/src/lambdas/deleteSavedChannel.ts
@@ -15,17 +15,13 @@ const SavedChannelRequestStruct = object({
 
 export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   if (!event.body) {
-    return createFailResponse(400, {
-      savedChannel: "User and/or channel data is missing.",
-    });
+    return createFailResponse(400, "User and/or channel data is missing.");
   }
 
   const requestBody = JSON.parse(event.body);
 
   if (!is(requestBody, SavedChannelRequestStruct)) {
-    return createFailResponse(400, {
-      savedChannel: "Incorrect user and/or channel data.",
-    });
+    return createFailResponse(400, "Incorrect user and/or channel data.");
   }
 
   const errorResponse = await handleDbConnection();
@@ -37,9 +33,7 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   );
 
   if (deleteResult.modifiedCount !== 1) {
-    return createFailResponse(500, {
-      user: "Failed to remove saved channel",
-    });
+    return createFailResponse(500, "Failed to remove saved channel");
   }
 
   // Channel removed from user's list of saved channels. Remove channel entirely if orphaned.

--- a/src/lambdas/deleteUser.ts
+++ b/src/lambdas/deleteUser.ts
@@ -46,15 +46,11 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   const userInformation = event.pathParameters;
 
   if (!userInformation) {
-    return createFailResponse(400, {
-      user: "User ID is required.",
-    });
+    return createFailResponse(400, "User ID is required.");
   }
 
   if (!is(userInformation, UserIdStruct)) {
-    return createFailResponse(400, {
-      user: "User ID is invalid.",
-    });
+    return createFailResponse(400, "User ID is invalid.");
   }
 
   const errorResponse = await handleDbConnection();
@@ -84,9 +80,7 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
     return createSuccessResponse(204, null);
   } catch (error) {
     await session.abortTransaction();
-    return createFailResponse(500, {
-      user: "Failed to delete user",
-    });
+    return createFailResponse(500, "Failed to delete user");
   } finally {
     session.endSession();
   }

--- a/src/lambdas/getUserSavedChannels.ts
+++ b/src/lambdas/getUserSavedChannels.ts
@@ -15,15 +15,11 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
   const userInformation = event.pathParameters;
 
   if (!userInformation) {
-    return createFailResponse(400, {
-      user: "User ID is missing.",
-    });
+    return createFailResponse(400, "User ID is missing.");
   }
 
   if (!is(userInformation, UserIdStruct)) {
-    return createFailResponse(400, {
-      user: "User ID is invalid.",
-    });
+    return createFailResponse(400, "User ID is invalid.");
   }
 
   const errorResponse = await handleDbConnection();
@@ -38,8 +34,6 @@ export const handler: Handler = async function (event: APIGatewayProxyEventV2) {
       savedChannels,
     });
   } else {
-    return createFailResponse(500, {
-      savedChannels: "Failed to retrieve saved channels.",
-    });
+    return createFailResponse(500, "Failed to retrieve saved channels.");
   }
 };

--- a/src/test/addChannel.test.ts
+++ b/src/test/addChannel.test.ts
@@ -23,9 +23,7 @@ it("returns bad request for missing body", async () => {
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          channel: "Channel data is required",
-        },
+        message: "Channel data is required",
       },
     })
   );
@@ -39,9 +37,7 @@ it("returns bad request for incorrect format of channel information", async () =
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          channel: "Incorrect channel data format",
-        },
+        message: "Incorrect channel data format",
       },
     })
   );

--- a/src/test/addSavedChannel.test.ts
+++ b/src/test/addSavedChannel.test.ts
@@ -23,9 +23,7 @@ it("returns bad request for missing body", async () => {
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          savedChannel: "User and/or channel data is missing.",
-        },
+        message: "User and/or channel data is missing.",
       },
     })
   );
@@ -43,9 +41,7 @@ it("returns bad request for incorrect format of channel information", async () =
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          savedChannel: "Incorrect user and/or channel data.",
-        },
+        message: "Incorrect user and/or channel data.",
       },
     })
   );

--- a/src/test/addUser.test.ts
+++ b/src/test/addUser.test.ts
@@ -23,9 +23,7 @@ it("returns bad request for missing body", async () => {
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          user: "User data is required.",
-        },
+        message: "User data is required.",
       },
     })
   );
@@ -39,9 +37,7 @@ it("returns bad request for incorrect format of user information", async () => {
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          user: "User data is invalid.",
-        },
+        message: "User data is invalid.",
       },
     })
   );

--- a/src/test/deleteChannel.test.ts
+++ b/src/test/deleteChannel.test.ts
@@ -22,9 +22,7 @@ it("returns bad request for missing path params", async () => {
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          channel: "Channel ID is required",
-        },
+        message: "Channel ID is required",
       },
     })
   );
@@ -38,9 +36,7 @@ it("returns bad request for incorrect format of channel information", async () =
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          channel: "Channel ID is incorrectly formatted",
-        },
+        message: "Channel ID is incorrectly formatted",
       },
     })
   );

--- a/src/test/deleteSavedChannel.test.ts
+++ b/src/test/deleteSavedChannel.test.ts
@@ -23,9 +23,7 @@ it("returns bad request for missing body", async () => {
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          savedChannel: "User and/or channel data is missing.",
-        },
+        message: "User and/or channel data is missing.",
       },
     })
   );
@@ -43,9 +41,7 @@ it("returns bad request for incorrect format of channel information", async () =
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          savedChannel: "Incorrect user and/or channel data.",
-        },
+        message: "Incorrect user and/or channel data.",
       },
     })
   );

--- a/src/test/deleteUser.test.ts
+++ b/src/test/deleteUser.test.ts
@@ -22,9 +22,7 @@ it("returns bad request for missing path params", async () => {
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          user: "User ID is required.",
-        },
+        message: "User ID is required.",
       },
     })
   );
@@ -38,9 +36,7 @@ it("returns bad request for incorrect format of user information", async () => {
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          user: "User ID is invalid.",
-        },
+        message: "User ID is invalid.",
       },
     })
   );

--- a/src/test/getUserSavedChannels.test.ts
+++ b/src/test/getUserSavedChannels.test.ts
@@ -22,9 +22,7 @@ it("returns bad request for missing parameters", async () => {
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          user: "User ID is missing.",
-        },
+        message: "User ID is missing.",
       },
     })
   );
@@ -42,9 +40,7 @@ it("returns bad request for incorrect format of user information", async () => {
       headers: { "Content-Type": "application/json" },
       body: {
         status: "fail",
-        data: {
-          user: "User ID is invalid.",
-        },
+        message: "User ID is invalid.",
       },
     })
   );

--- a/src/test/handleConnectDb.test.ts
+++ b/src/test/handleConnectDb.test.ts
@@ -1,4 +1,4 @@
-import { handleDbConnection, createErrorResponse } from "@/helpers";
+import { handleDbConnection, createFailResponse } from "@/helpers";
 import { connectDb } from "@/config";
 
 jest.mock("@/config/mongo");
@@ -14,7 +14,7 @@ describe("DB Handler", () => {
     (connectDb as jest.Mock).mockRejectedValue(new Error());
     const result = await handleDbConnection();
     expect(result).toEqual(
-      createErrorResponse(
+      createFailResponse(
         500,
         "An error occurred while attempting to connect to the database."
       )


### PR DESCRIPTION
This PR consolidates the JSend inspired "fail" and "error" responses into a single "fail" response.

Changes with this MR:
- All errors now return a response with status `fail` 
- All `fail` responses now include a message rather than data
- Test have been updated with these changes